### PR TITLE
Fixed Liberty configuration

### DIFF
--- a/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestPolicy.java
+++ b/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestPolicy.java
@@ -10,8 +10,13 @@ import java.security.Permissions;
 import java.security.Policy;
 import java.security.Principal;
 import java.security.ProtectionDomain;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
  
 public class TestPolicy extends Policy {
      
@@ -44,8 +49,15 @@ public class TestPolicy extends Policy {
                 return true;
             }
         }
+		
+		Subject subject;
+		try {
+			subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
+		} catch (PolicyContextException ex) {
+			throw new RuntimeException(ex);
+		}
          
-        if (hasAccessViaRoles(policyConfiguration.getPerRolePermissions(), roleMapper.getMappedRolesFromPrincipals(currentUserPrincipals), permission)) {
+        if (hasAccessViaRoles(policyConfiguration.getPerRolePermissions(), roleMapper.getMappedRoles(currentUserPrincipals, subject), permission)) {
             // Access is granted via role. Note that if this returns false it doesn't mean the permission is not
             // granted. A role can only grant, not take away permissions.
             return true;
@@ -86,13 +98,22 @@ public class TestPolicy extends Policy {
         // Thirdly, get all unchecked permissions
         collectPermissions(policyConfiguration.getUncheckedPermissions(), permissions, excludedPermissions);
  
-        // Finally get the permissions for each role *that the current user has*
+        
+		Subject subject;
+		try {
+			subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
+		} catch (PolicyContextException ex) {
+			throw new RuntimeException(ex);
+		}
+		
+		// Finally get the permissions for each role *that the current user has*
         //
         // Note that the principles that are put into the ProtectionDomain object are those from the current user.
         // (for a Server application, passing in a Subject would have been more logical, but the Policy class was
-        // made for Java SE with code-level security in mind)
+        // made for Java SE with code-level security in mind). The Subject needs to be passed anyway as some servers
+		// (namely WebSphere Liberty/OpenLiberty) are only accesible from the Subject
         Map<String, Permissions> perRolePermissions = policyConfiguration.getPerRolePermissions();
-        for (String role : roleMapper.getMappedRolesFromPrincipals(domain.getPrincipals())) {
+        for (String role : roleMapper.getMappedRoles(domain.getPrincipals(), subject)) {
             if (perRolePermissions.containsKey(role)) {
                 collectPermissions(perRolePermissions.get(role), permissions, excludedPermissions);
             }

--- a/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestPolicy.java
+++ b/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestPolicy.java
@@ -49,13 +49,13 @@ public class TestPolicy extends Policy {
                 return true;
             }
         }
-		
-		Subject subject;
-		try {
-			subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
-		} catch (PolicyContextException ex) {
-			throw new RuntimeException(ex);
-		}
+        
+        Subject subject;
+        try {
+            subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
+        } catch (PolicyContextException ex) {
+            throw new RuntimeException(ex);
+        }
          
         if (hasAccessViaRoles(policyConfiguration.getPerRolePermissions(), roleMapper.getMappedRoles(currentUserPrincipals, subject), permission)) {
             // Access is granted via role. Note that if this returns false it doesn't mean the permission is not
@@ -99,19 +99,19 @@ public class TestPolicy extends Policy {
         collectPermissions(policyConfiguration.getUncheckedPermissions(), permissions, excludedPermissions);
  
         
-		Subject subject;
-		try {
-			subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
-		} catch (PolicyContextException ex) {
-			throw new RuntimeException(ex);
-		}
-		
-		// Finally get the permissions for each role *that the current user has*
+        Subject subject;
+        try {
+            subject = (Subject)PolicyContext.getContext("javax.security.auth.Subject.container");
+        } catch (PolicyContextException ex) {
+            throw new RuntimeException(ex);
+        }
+        
+        // Finally get the permissions for each role *that the current user has*
         //
         // Note that the principles that are put into the ProtectionDomain object are those from the current user.
         // (for a Server application, passing in a Subject would have been more logical, but the Policy class was
         // made for Java SE with code-level security in mind). The Subject needs to be passed anyway as some servers
-		// (namely WebSphere Liberty/OpenLiberty) are only accesible from the Subject
+        // (namely WebSphere Liberty/OpenLiberty) are only accesible from the Subject
         Map<String, Permissions> perRolePermissions = policyConfiguration.getPerRolePermissions();
         for (String role : roleMapper.getMappedRoles(domain.getPrincipals(), subject)) {
             if (perRolePermissions.containsKey(role)) {

--- a/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
+++ b/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
@@ -10,7 +10,9 @@ import java.security.Principal;
 import java.security.acl.Group;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -104,20 +106,30 @@ public class TestRoleMapper {
         }
     }
 
-    public List<String> getMappedRolesFromPrincipals(Principal[] principals) {
-        return getMappedRolesFromPrincipals(asList(principals));
+    public List<String> getMappedRoles(Principal[] principals, Subject subject) {
+        return getMappedRoles(asList(principals), subject);
     }
 
     public boolean isAnyAuthenticatedUserRoleMapped() {
         return anyAuthenticatedUserRoleMapped;
     }
 
-    public List<String> getMappedRolesFromPrincipals(Iterable<Principal> principals) {
+    /**
+	 * Tries to get the roles from the principals list and only if it fails,
+	 * fallbacks to looking at the Subject.
+	 * 
+	 * Liberty is the only known server that falls back.
+	 *
+	 * @param principals
+	 * @param subject
+	 * @return
+	 */
+	public List<String> getMappedRoles(Iterable<Principal> principals, Subject subject) {
 
         // Extract the list of groups from the principals. These principals typically contain
         // different kind of principals, some groups, some others. The groups are unfortunately vendor
         // specific.
-        List<String> groups = getGroupsFromPrincipals(principals);
+        List<String> groups = getGroups(principals, subject);
 
         // Map the groups to roles. E.g. map "admin" to "administrator". Some servers require this.
         return mapGroupsToRoles(groups);
@@ -165,7 +177,7 @@ public class TestRoleMapper {
                 if (roleToSubjectMap.containsKey(role)) {
                     Set<Principal> principals = roleToSubjectMap.get(role).getPrincipals();
 
-                    List<String> groups = getGroupsFromPrincipals(principals);
+                    List<String> groups = getGroups(principals, null);
                     for (String group : groups) {
                         if (!groupToRoles.containsKey(group)) {
                             groupToRoles.put(group, new ArrayList<String>());
@@ -286,9 +298,10 @@ public class TestRoleMapper {
      * Extracts the roles from the vendor specific principals. SAD that this is needed :(
      *
      * @param principals
+	 * @param subject the (possibly null) subject
      * @return
      */
-    public List<String> getGroupsFromPrincipals(Iterable<Principal> principals) {
+    public List<String> getGroups(Iterable<Principal> principals, Subject subject) {
         List<String> groups = new ArrayList<>();
 
         for (Principal principal : principals) {
@@ -298,6 +311,21 @@ public class TestRoleMapper {
                 return groups;
             }
         }
+		
+		if(subject == null) {
+			return groups;
+		}
+		
+		@SuppressWarnings("rawtypes")
+		Set<Hashtable> tables = subject.getPrivateCredentials(Hashtable.class);
+        if (tables != null && !tables.isEmpty()) {
+			@SuppressWarnings("rawtypes")
+			Hashtable table = tables.iterator().next();
+			
+			groups = (List<String>) table.get("com.ibm.wsspi.security.cred.groups");
+			
+			return groups != null ? groups : Collections.emptyList();
+		}
 
         return groups;
     }

--- a/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
+++ b/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
@@ -316,8 +316,8 @@ public class TestRoleMapper {
             return groups;
     }
         
-    @SuppressWarnings("rawtypes")
-    Set<Hashtable> tables = subject.getPrivateCredentials(Hashtable.class);
+        @SuppressWarnings("rawtypes")
+        Set<Hashtable> tables = subject.getPrivateCredentials(Hashtable.class);
         if (tables != null && !tables.isEmpty()) {
             @SuppressWarnings("rawtypes")
             Hashtable table = tables.iterator().next();

--- a/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
+++ b/jacc-provider/src/main/java/org/omnifaces/jaccprovider/TestRoleMapper.java
@@ -115,16 +115,16 @@ public class TestRoleMapper {
     }
 
     /**
-	 * Tries to get the roles from the principals list and only if it fails,
-	 * fallbacks to looking at the Subject.
-	 * 
-	 * Liberty is the only known server that falls back.
-	 *
-	 * @param principals
-	 * @param subject
-	 * @return
-	 */
-	public List<String> getMappedRoles(Iterable<Principal> principals, Subject subject) {
+     * Tries to get the roles from the principals list and only if it fails,
+     * fallbacks to looking at the Subject.
+     * 
+     * Liberty is the only known server that falls back.
+     *
+     * @param principals
+     * @param subject
+     * @return
+     */
+    public List<String> getMappedRoles(Iterable<Principal> principals, Subject subject) {
 
         // Extract the list of groups from the principals. These principals typically contain
         // different kind of principals, some groups, some others. The groups are unfortunately vendor
@@ -298,7 +298,7 @@ public class TestRoleMapper {
      * Extracts the roles from the vendor specific principals. SAD that this is needed :(
      *
      * @param principals
-	 * @param subject the (possibly null) subject
+     * @param subject the (possibly null) subject
      * @return
      */
     public List<String> getGroups(Iterable<Principal> principals, Subject subject) {
@@ -311,21 +311,21 @@ public class TestRoleMapper {
                 return groups;
             }
         }
-		
-		if(subject == null) {
-			return groups;
-		}
-		
-		@SuppressWarnings("rawtypes")
-		Set<Hashtable> tables = subject.getPrivateCredentials(Hashtable.class);
+        
+        if(subject == null) {
+            return groups;
+    }
+        
+    @SuppressWarnings("rawtypes")
+    Set<Hashtable> tables = subject.getPrivateCredentials(Hashtable.class);
         if (tables != null && !tables.isEmpty()) {
-			@SuppressWarnings("rawtypes")
-			Hashtable table = tables.iterator().next();
-			
-			groups = (List<String>) table.get("com.ibm.wsspi.security.cred.groups");
-			
-			return groups != null ? groups : Collections.emptyList();
-		}
+            @SuppressWarnings("rawtypes")
+            Hashtable table = tables.iterator().next();
+            
+            groups = (List<String>) table.get("com.ibm.wsspi.security.cred.groups");
+            
+            return groups != null ? groups : Collections.emptyList();
+        }
 
         return groups;
     }

--- a/liberty-bundle/pom.xml
+++ b/liberty-bundle/pom.xml
@@ -15,6 +15,7 @@
 	<name>JACC Provider Liberty OSGi Bundle</name>
 
 	<build>
+		<finalName>testjacc</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
@@ -53,13 +54,13 @@
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component</artifactId>
-			<version>1.4.0</version>
+			<version>1.3.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.service.component.annotations</artifactId>
-			<version>1.4.0</version>
+			<version>1.3.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/liberty-bundle/src/main/java/org/omnifaces/jaccproviderliberty/MyJaccProviderService.java
+++ b/liberty-bundle/src/main/java/org/omnifaces/jaccproviderliberty/MyJaccProviderService.java
@@ -21,8 +21,6 @@ import org.osgi.service.component.annotations.Deactivate;
 )
 public class MyJaccProviderService implements ProviderService {
 
-	private Map<String, String> configProps;
-
 	@Override
 	public Policy getPolicy() {
 		return new TestPolicy();
@@ -49,7 +47,6 @@ public class MyJaccProviderService implements ProviderService {
 
 	@Activate
 	protected void activate(ComponentContext cc) {
-		configProps = (Map<String, String>) cc.getProperties();
 	}
 
 	@Deactivate

--- a/liberty-bundle/src/main/resources/META-INF/testjacc.mf
+++ b/liberty-bundle/src/main/resources/META-INF/testjacc.mf
@@ -4,6 +4,7 @@ IBM-ShortName: testjacc
 Subsystem-SymbolicName: testjacc;visibility:=public
 Subsystem-Version: 0.2
 Subsystem-Type: osgi.subsystem.feature
-Subsystem-Content: TestJaccBundle;version="0.2"
+Subsystem-Content: org.omnifaces.jacc-provider-liberty-bundle;version="0.2"
+ com.ibm.websphere.javaee.jacc.1.5;version="[1,1.0.200)";location:="dev/api/spec/"
 Manifest-Version: 1.0
 IBM-API-Package: org.omnifaces.jaccprovider


### PR DESCRIPTION
There were some errors.

FYI, as I read on your blog you also had some problems:
- Liberty `org.osgi.service.component.annotations` bundle seems to be at version 1.3 now. Probably 1.2 at the time you tried. That's why it couldn't find the bundle.
- The ` com.ibm.ws.javaee.jacc.1.5;version="[1,1.0.200)";location:="dev/api/spec/"` line is actually `com.ibm.**websphere**.javaee.jacc` and needs a blank space between dependencies (https://www.ibm.com/support/knowledgecenter/en/SSGMCP_5.3.0/com.ibm.cics.ts.java.doc/topics/jacc_overview.html)

I plan to provide a README.md for this once we have Soteria tests passing with it.